### PR TITLE
Move assignment instructions to task folders

### DIFF
--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -4,7 +4,7 @@ If you'd like to contribute, please submit a Pull Request to this repo.
 
 ## New Assignments
 
-For new assignments, please add a new folder under [api](https://github.com/Points/interview-test-server/tree/master/api) and keep the work isolated to there. If you wish to make improvements outside of the scope of your assignment, please submit them under another Pull Request.
+For new assignments, please add a new folder under [api](https://github.com/Points/interview-test-server/tree/master/api) and keep the work isolated to there. If you wish to make improvements outside of the scope of your assignment, please submit another Pull Request.
 
 You can link the routes to your assignment at the bottom of [app.py](https://github.com/Points/interview-test-server/blob/master/app.py#L37).
 

--- a/CONTRIBUTIONS.md
+++ b/CONTRIBUTIONS.md
@@ -4,9 +4,13 @@ If you'd like to contribute, please submit a Pull Request to this repo.
 
 ## New Assignments
 
-For new assignments, please add a new folder under [api](https://github.com/Points/interview-test-server/tree/master/api) and keep the work isolated to there. If you wish to make improvements outside of the scope of your assignment, please submit another Pull Request.
+For new assignments, please add a new folder under [api](./api/) and keep the work isolated to there. If you wish to make improvements outside of the scope of your assignment, please submit another Pull Request. Your assignment should include:
 
-You can link the routes to your assignment at the bottom of [app.py](https://github.com/Points/interview-test-server/blob/master/app.py#L37).
+* *INSTRUCTIONS.md*: a markdown file explaining the task
+* HTML Instructions: An html page in the [templates folder](./templates/) containing similar contents to the newly created INSTRUCTIONS.md file
+* `routes.py`: A list of routes relating to this assignment. The root should contain instructions, the sub-routes should contain restful endpoints. These endpoints will be linked at the bottom of [app.py](./app.py#L40).
+
+_See the [tax calculator](./api/tax_calculator) assignment as an example implementation_
 
 ## Local Development
 

--- a/README.md
+++ b/README.md
@@ -1,92 +1,13 @@
 # Interview Test Server
 
-For the Points developer take-home assignment, the following task is required: you are to build a tax calculator against
- this API. The purpose is to develop an income tax calculator to help illustrate how marginal taxes work. This server is
- pretty simple, only returning the tax rates for a given year. You are to calculate the amount of taxes owed by 
- inputting a yearly salary, then displaying the different rates, the total amount owed and the effective tax rates.
+Welcome to the Points developer take-home assignment.
 
-## Instructions
-For all of the below assignments there are different levels that you can work on:
- * **Level 1:** The easier level, the API always behaves and the response never changes.
- * **Level 2:** More difficult, the API doesn't always behave and includes gotchas.
- 
-If you complete the first level with ease, feel free to jump to the next one. 
+Your task is to build an app against a small API. [Download the docker image](#Getting-started) onto your computer and run it locally. The instructions for each assignment live at the base of the API routes, as well as in the respective *INSTRUCTIONS.md* files. You may choose one of the following tasks:
+
+* [Autonomous Car](./api/autonomous_car/INSTRUCTIONS.md)
+* [Tax Calculator](./api/tax_calculator/INSTRUCTIONS.md)
 
 **Please timebox your solution to one day total.**
-
-## Assignment 1: Tax Calculator
-
-### Instructions
-
-* Download and run this server (see [Getting Started](#getting-started))
-* Build an application / tool in a language as agreed with your hiring manager:
-    * Fetches the tax rates from this API server
-    * Takes a yearly salary as input
-    * Calculates and displays the total taxes owed for the salary
-    * Displays the amount of taxes owed per band
-    * Displays the effective rate
-
-### Level 1
-
-* Fetch the tax rates from this server at: [localhost:5000/tax-calculator/brackets](http://localhost:5000/tax-calculator/brackets)
-
-### Level 2 *(sometimes returns bad responses, handle accordingly)*
-
-* Fetch the tax rates by year: [localhost:5000/tax-calculator/brackets/<2019,2020...>](http://localhost:5000/tax-calculator/brackets/2020)
-
-## Assignment 2: Autonomous Car
-
-### Description
-
-Points is developing an autonomous vehicle program. It's going well, but we need to iron out a few bugs. The 
- Engineering Team would like to demo our progress to the Product Team, so we need to develop a tool that can take 
- track and travel log data, and then determine whether our autonomous vehicle successfully navigated the track.
-
-Track and travel log data are encoded as JSON. The "track" array contains entries for any position of the track where 
- there is an obstacle in any of the 3 lanes (`"a"`, `"b"` or `"c"`). The "travelLog" array contains entries for any 
- position of the track where the car has changed lanes, either to the `"left"` or `"right"`.
-
-The autonomous car starts at position `0` on lane `"b"`, drives itself to the end of the track and can shift only one
- lane per position. The simulation should end when the car hits an obstacle, goes out-of-bounds, or when all "track" 
- and "travelLog" entries have been processed.
- 
-### Instructions
-
-1. Download and run this server (see [Getting Started](#getting-started)).
-2. Build an application / tool in a language as agreed with your hiring manager:
-   * Fetches an autonomous car route JSON object from this API server (see the different levels below). 
-   * Use the route object's "track" & "travelLog" information to determine if the simulation will end successfully or
-     if it will fail. 
-   * If the simulation results in a success, the application must return the following success response:
-     ```json 
-     {"status":  "success"}
-     ```
-   * If the simulation results in a failure (running out of bounds or hitting an obstacle), the application must 
-     return an error response showing at which position the simulation fails:
-     ```json 
-     {"status":  "error", "position": 2}
-     ```
-            
-### Level 1
-
-For this level, you can use fetch a static route object from each of the following endpoints:
- * [/autonomous-car/routes/empty-route](http://localhost:5000/autonomous-car/routes/empty-route) will return a route
-   object with an empty "track" and "travelLog" arrays.
- * [/autonomous-car/routes/success-no-obstacles](http://localhost:5000/autonomous-car/routes/success-no-obstacles) 
-   will return a route object that should result in a successful simulation, **with zero obstacles on the track**.
- * [/autonomous-car/routes/success-with-obstacles](http://localhost:5000/autonomous-car/routes/success-with-obstacles) 
-   will return a route object that should result in a successful simulation, **with obstacles on the track**.
- * [/autonomous-car/routes/failure-out-of-bounds](http://localhost:5000/autonomous-car/routes/failure-out-of-bounds) 
-   will return a route object that should result in failure due to running out of bounds.
- * [/autonomous-car/routes/failure-hits-obstacle](http://localhost:5000/autonomous-car/routes/failure-hits-obstacle) 
-   will return a route object that should result in failure due to running into an obstacle.
-
-
-### Level 2 *(sometimes returns bad responses, handle accordingly)*
-
-For this level, you can fetch a random route (including the empty-route) using the endpoint:
-* [/autonomous-car/routes/random](http://localhost:5000/autonomous-car/routes/random)
-
 
 ## Getting started
 
@@ -95,7 +16,7 @@ docker pull ptsdocker16/interview-test-server
 docker run --init -p 5000:5000 -it ptsdocker16/interview-test-server
 ```
 
-Navigate to http://localhost:5000. You should see a brief set of instructions. From there you'll be able to query the above endpoints and do your assignments. If you have any problems, email the Team Lead or Engineering Hiring Manager for assistance.
+Navigate to [http://localhost:5000](http://localhost:5000). You should see a brief set of instructions. From there you'll be able to query the above endpoints and do your assignment. If you have any problems or need any sort of clarification, email the Team Lead or Engineering Hiring Manager for assistance.
 
 ## Submission Instructions
 

--- a/api/autonomous_car/INSTRUCTIONS.md
+++ b/api/autonomous_car/INSTRUCTIONS.md
@@ -1,0 +1,54 @@
+## The Autonomous Car
+
+Points is developing an autonomous vehicle program. It's going well, but we need to iron out a few bugs. The
+ Engineering Team would like to demo our progress to the Product Team, so we need to develop a tool that can take
+ track and travel log data, and then determine whether our autonomous vehicle successfully navigated the track.
+
+Track and travel log data are encoded as JSON. The "track" array contains entries for any position of the track where
+ there is an obstacle in any of the 3 lanes (`"a"`, `"b"` or `"c"`). The "travelLog" array contains entries for any
+ position of the track where the car has changed lanes, either to the `"left"` or `"right"`.
+
+The autonomous car starts at position `0` on lane `"b"`, drives itself to the end of the track and can shift only one
+ lane per position. The simulation should end when the car hits an obstacle, goes out-of-bounds, or when all "track"
+ and "travelLog" entries have been processed.
+
+### Instructions
+
+1. Download and run this server (see [Getting Started](../../README.md#getting-started)).
+2. Build an application / tool in a language as agreed with your hiring manager:
+   * Fetches an autonomous car route JSON object from this API server (see the different levels below).
+   * Use the route object's "track" & "travelLog" information to determine if the simulation will end successfully or
+     if it will fail.
+   * If the simulation results in a success, the application must return the following success response:
+     ```json
+     {"status":  "success"}
+     ```
+   * If the simulation results in a failure (running out of bounds or hitting an obstacle), the application must
+     return an error response showing at which position the simulation fails:
+     ```json
+     {"status":  "error", "position": 2}
+     ```
+
+**Please timebox your solution to one day**
+
+### Level 1
+
+For this level, you can use fetch a static route object from each of the following endpoints:
+ * [/autonomous-car/routes/empty-route](http://localhost:5000/autonomous-car/routes/empty-route) will return a route
+   object with an empty "track" and "travelLog" arrays.
+ * [/autonomous-car/routes/success-no-obstacles](http://localhost:5000/autonomous-car/routes/success-no-obstacles)
+   will return a route object that should result in a successful simulation, **with zero obstacles on the track**.
+ * [/autonomous-car/routes/success-with-obstacles](http://localhost:5000/autonomous-car/routes/success-with-obstacles)
+   will return a route object that should result in a successful simulation, **with obstacles on the track**.
+ * [/autonomous-car/routes/failure-out-of-bounds](http://localhost:5000/autonomous-car/routes/failure-out-of-bounds)
+   will return a route object that should result in failure due to running out of bounds.
+ * [/autonomous-car/routes/failure-hits-obstacle](http://localhost:5000/autonomous-car/routes/failure-hits-obstacle)
+   will return a route object that should result in failure due to running into an obstacle.
+
+
+### Level 2
+
+_sometimes returns bad responses, handle accordingly_
+
+For this level, you can fetch a random route (including the empty-route) using the endpoint:
+* [/autonomous-car/routes/random](http://localhost:5000/autonomous-car/routes/random)

--- a/api/tax_calculator/INSTRUCTIONS.md
+++ b/api/tax_calculator/INSTRUCTIONS.md
@@ -1,0 +1,26 @@
+## Tax Calculator
+
+The purpose is to develop an income tax calculator to help illustrate how marginal taxes work. This server is pretty simple, only returning the tax rates for a given year. You are to calculate the amount of taxes owed by inputting a yearly salary, then displaying *the rates per bracket*, *the total amount owed* and *the effective tax rates*.
+
+There are two different levels, if you complete the first one with ease, feel free to work on the next one, which returns similar information, but with weird side effects.
+
+**Please timebox your solution to one day**
+
+### Instructions
+
+* Download and run this server (see [Getting Started](../../README.md#getting-started))
+* Build an application / tool in a language as agreed with your hiring manager:
+    * Fetches the tax rates from this API server
+    * Takes a yearly salary as input
+    * Calculates and displays the total taxes owed for the salary
+    * Displays the amount of taxes owed per band
+    * Displays the effective rate
+
+### Level 1
+
+* Fetch the tax rates from this server at: [localhost:5000/tax-calculator/brackets](http://localhost:5000/tax-calculator/brackets)
+
+### Level 2
+_sometimes returns bad responses, handle accordingly_
+
+* Fetch the tax rates by year: [localhost:5000/tax-calculator/brackets/<2019,2020...>](http://localhost:5000/tax-calculator/brackets/2020)


### PR DESCRIPTION
There was too much going on in the README, so it has been broken out into the INSTRUCTIONS.md for each of the provided assignments.